### PR TITLE
Remove doc of unstable feature of never type

### DIFF
--- a/src/types/never.md
+++ b/src/types/never.md
@@ -5,18 +5,12 @@
 
 The never type `!` is a type with no values, representing the result of
 computations that never complete. Expressions of type `!` can be coerced into
-any other type.
+any other type. 
 
-<!-- ignore: unstable -->
-```rust,ignore
-let x: ! = panic!();
-// Can be coerced into any type.
-let y: u32 = x;
+The `!` type can **only** appear in function return types presently.
+
+```rust
+extern "C" {
+    pub fn abort() -> !;
+}
 ```
-
-**NB.** The never type was expected to be stabilized in 1.41, but due
-to some last minute regressions detected the stabilization was
-temporarily reverted. The `!` type can only appear in function return
-types presently. See [the tracking
-issue](https://github.com/rust-lang/rust/issues/35121) for more
-details.


### PR DESCRIPTION
Remove unstable feature of never type from doc

---

https://doc.rust-lang.org/reference/types/never.html


Gives example which is unstable
```
let x: ! = panic!();
// Can be coerced into any type.
let y: u32 = x;
```

But not giving example for what has been stabilized
```
extern "C" {
    pub fn abort() -> !;
}
```

This is really confusing for newcomers:
1. The Rust reference does not mention unstable feature, except this one
2. The doc says
> NB. The never type was expected to be stabilized in 1.41, but due to some last minute regressions detected the stabilization was temporarily reverted. The ! type can only appear in function return types presently. See [the tracking issue](https://github.com/rust-lang/rust/issues/35121) for more details.

Some people stops reading when they realize never type is unstable,
not seeing `The ! type can only appear in function return types presently`


I suggest to make the doc consistent, only show stabilized stuffs